### PR TITLE
Add QOL changes to permission middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,5 @@ import permissionsMiddleware, { humanReadable } from '@discord-rose/permissions-
 
 ## Default readable permissions
 
-[Can be viewed here.](./permissions-middleware/blob/master/index.js#L1)
+[Can be viewed here.](./index.js#L1)
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ When using `permissionsMiddleware()` you can pass a custom message object with a
 By default it is 
 ```js
 {
-  user = (ctx) => `You're the following permissions: ${ctx.command.userPerms.join(', ')}`,
-  my = (ctx) => `I'm missing the following permissions: ${ctx.command.myPerms.join(', ')}`
+  my = (ctx) => `I am missing the following permissions: \`${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``,
+  user = (ctx) => `You are missing the following permissions: \`${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ worker.commands
   })
 ```
 
+## Using discord-rose's error logging
+
+When using `permissionsMiddleware()` by default it will send the error as a plain text message to the user. If you want to have discord-rose send the error with its error handler you can add an option in the function:
+```js
+permissionsMiddleware({
+  sendAsRoseError: true
+})
+```
+
+This will work with any custom messages you set.
+
 ## Custom message
 
 When using `permissionsMiddleware()` you can pass a custom message object with a function, that takes a function which takes the command context:

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ When using `permissionsMiddleware()` you can pass a custom message object with a
 By default it is 
 ```js
 {
-  my = (ctx) => `I am missing the following permissions: \`${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``,
-  user = (ctx) => `You are missing the following permissions: \`${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``
+  my = (ctx) => `I am missing the following permissions: ${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join(', ')}`,
+  user = (ctx) => `You are missing the following permissions: ${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join(', ')}\`
 }
 ```
-This will result in a message like: "I am missing the following permissions: `Embed Links`" or "You are missing the following permissions: `Manage Messages`"
+This will result in a message like: "I am missing the following permissions: Embed Links, Add Reactions" or "You are missing the following permissions: Manage Messages"
 This will only show the permissions that are missing and not all the required permissions for the command. To show all the permissions the command uses [this](#using-the-default-readable-permissions) setup would show all the perms.
 
 

--- a/README.md
+++ b/README.md
@@ -35,27 +35,10 @@ worker.commands
   })
 ```
 
-#### Using discord-rose's error logging
-
-When using `permissionsMiddleware()` by default it will send the error as a  rose error message to the user. If you want to have the handler send the message in plain text you and add the following:
-```js
-permissionsMiddleware({
-  sendAsRoseError: false
-})
-```
-This will work with any custom messages you set.
-
-#### Replying to the original message
-
-If you are using the the plain text response ([sendAsRoseError: false](#using-discord-roses-error-logging "sendAsRoseError = false")) you can have the response reply to the executors message:
-```js
-permsissionsMiddleare({
-  makeResponseAReply: true
-})
-```
 
 
-## Custom message
+
+## Creating a custom message
 
 When using `permissionsMiddleware()` you can pass a custom message object with a function, that takes a function which takes the command context:
 ```js
@@ -68,8 +51,8 @@ When using `permissionsMiddleware()` you can pass a custom message object with a
 By default it is 
 ```js
 {
-  my = (perms, ctx) => `I am missing the following permissions: ${perms.map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
-  user = (perms, ctx) => `You are missing the following permissions: ${perms.map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
+  my = (perms, _ctx) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
+  user = (perms, _ctx) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
 }
 ```
 This will result in a message like: "I am missing the following permissions: Embed Links, Add Reactions" or "You are missing the following permissions: Manage Messages"
@@ -85,6 +68,7 @@ worker.commands
 ```
 
 
+
 ## Using the default readable permissions
 
 Creating custom messages but using the provided readable permissions:
@@ -94,6 +78,8 @@ permissionsMiddleware({
   my: (perms, ctx) => `You don't have the required permissions you need: ${ctx.command.myPerms.map(p => permissionsMiddleware.humanReadable[p])}`
 })
 ```
+
+This will also list all of the permissions required by the command. The `perms` parameter only lists the permissions that are missing.
 
 #### Using Typescript
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ When using `permissionsMiddleware()` you can pass a custom message object with a
 By default it is 
 ```js
 {
-  my = (_ctx, perms) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
-  user = (_ctx, perms) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
+  my = (ctx, perms) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
+  user = (ctx, perms) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
 }
 ```
 This will result in a message like: "I am missing the following permissions: Embed Links, Add Reactions" or "You are missing the following permissions: Manage Messages"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ worker.commands
   })
 ```
 
-## Using discord-rose's error logging
+#### Using discord-rose's error logging
 
 When using `permissionsMiddleware()` by default it will send the error as a  rose error message to the user. If you want to have the handler send the message in plain text you and add the following:
 ```js
@@ -43,56 +43,72 @@ permissionsMiddleware({
   sendAsRoseError: false
 })
 ```
-- **Note:** If the permission "embed" is required and fails it will send as plain text. (this is a limitation of how rose sends errors)
-
 This will work with any custom messages you set.
 
-## Replying to the original message
+#### Replying to the original message
 
-If you are using the the plain text response ([sendAsRoseError: false](#using-discord-roses-error-logging "sendAsRoseError = false")) you can have the reponse reply to the executors message:
+If you are using the the plain text response ([sendAsRoseError: false](#using-discord-roses-error-logging "sendAsRoseError = false")) you can have the response reply to the executors message:
 ```js
 permsissionsMiddleare({
   makeResponseAReply: true
 })
 ```
+
+
 ## Custom message
 
 When using `permissionsMiddleware()` you can pass a custom message object with a function, that takes a function which takes the command context:
 ```js
 {
-  user: (ctx) => ...,//
-  my: (ctx) => ... //
+  user: (perms, ctx) => ...,//
+  my: (perms, ctx) => ... //
 }
 ```
 
 By default it is 
 ```js
 {
-  my = (ctx) => `I am missing the following permissions: ${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join(', ')}`,
-  user = (ctx) => `You are missing the following permissions: ${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join(', ')}\`
+  my = (perms, ctx) => `I am missing the following permissions: ${perms.map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
+  user = (perms, ctx) => `You are missing the following permissions: ${perms.map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
 }
 ```
 This will result in a message like: "I am missing the following permissions: Embed Links, Add Reactions" or "You are missing the following permissions: Manage Messages"
 This will only show the permissions that are missing and not all the required permissions for the command. To show all the permissions the command uses [this](#using-the-default-readable-permissions) setup would show all the perms.
 
-
-Example for creating a custom message:
+#### Example for creating a custom message:
 
 ```js
 worker.commands
   .middleware(permissionsMiddleware({
-    user: (ctx) => "You don't have permissions"
+    user: (perms, ctx) => "You don't have permissions"
   }))
 ```
+
+
 ## Using the default readable permissions
+
 Creating custom messages but using the provided readable permissions:
 ```js
 permissionsMiddleware({
-  user: (ctx) => `You don't have the required permissions you need: ${ctx.command.userPerms.map(p => permissionsMiddleware.humanReadable[p])}`
+  user: (perms, ctx) => `You don't have the required permissions you need: ${ctx.command.userPerms.map(p => permissionsMiddleware.humanReadable[p])}`,
+  my: (perms, ctx) => `You don't have the required permissions you need: ${ctx.command.myPerms.map(p => permissionsMiddleware.humanReadable[p])}`
 })
 ```
 
-## Default readable permisisons
+#### Using Typescript
+
+To import humanReadable in Typescript you need to import permissionsMiddleware as follows:
+
+```typescript
+import permissionsMiddleware, { humanReadable } from '@discord-rose/permissions-middleware'
+```
+
+
+
+
+
+## Default readable permissions
+
 ```json
 {
   createInvites: 'Create Invites',
@@ -128,4 +144,3 @@ permissionsMiddleware({
   emojis: 'Manage Emojis'
 }
 ```
-[1]: #custom

--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ worker.commands
 When using `permissionsMiddleware()` you can pass a custom message object with a function, that takes a function which takes the command context:
 ```js
 {
-  user: (perms, ctx) => ...,//
-  my: (perms, ctx) => ... //
+  user: (ctx, perms) => ...,//
+  my: (ctx, perms) => ... //
 }
 ```
 
 By default it is 
 ```js
 {
-  my = (perms, _ctx) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
-  user = (perms, _ctx) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
+  my = (_ctx, perms) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
+  user = (_ctx, perms) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
 }
 ```
 This will result in a message like: "I am missing the following permissions: Embed Links, Add Reactions" or "You are missing the following permissions: Manage Messages"
@@ -63,7 +63,7 @@ This will only show the permissions that are missing and not all the required pe
 ```js
 worker.commands
   .middleware(permissionsMiddleware({
-    user: (perms, ctx) => "You don't have permissions"
+    user: (ctx, perms) => "You don't have permissions"
   }))
 ```
 
@@ -74,8 +74,8 @@ worker.commands
 Creating custom messages but using the provided readable permissions:
 ```js
 permissionsMiddleware({
-  user: (perms, ctx) => `You don't have the required permissions you need: ${ctx.command.userPerms.map(p => permissionsMiddleware.humanReadable[p])}`,
-  my: (perms, ctx) => `You don't have the required permissions you need: ${ctx.command.myPerms.map(p => permissionsMiddleware.humanReadable[p])}`
+  user: (ctx, perms) => `You don't have the required permissions you need: ${ctx.command.userPerms.map(p => permissionsMiddleware.humanReadable[p])}`,
+  my: (ctx, perms) => `You don't have the required permissions you need: ${ctx.command.myPerms.map(p => permissionsMiddleware.humanReadable[p])}`
 })
 ```
 
@@ -95,38 +95,5 @@ import permissionsMiddleware, { humanReadable } from '@discord-rose/permissions-
 
 ## Default readable permissions
 
-```json
-{
-  createInvites: 'Create Invites',
-  kick: 'Kick Members',
-  ban: 'Ban Members',
-  administrator: 'Administrator',
-  manageChannels: 'Manage Channels',
-  manageGuild: 'Manage Server',
-  addReactions: 'Add Reactions',
-  auditLog: 'View Audit Log',
-  prioritySpeaker: 'Priority Speaker',
-  stream: 'Stream',
-  viewChannel: 'View Channel(s)',
-  sendMessages: 'Send Messages',
-  tts: 'Send Text-to-Speech Messages',
-  manageMessages: 'Manage Messages',
-  embed: 'Embed Links',
-  files: 'Attach Files',
-  readHistory: 'Read Message History',
-  mentionEveryone: 'Mention \@everyone, \@here, and All Roles',
-  externalEmojis: 'Use External Emoji',
-  viewInsights: 'View Server Invites',
-  connect: 'Connect (Voice)',
-  speak: 'Speak (Voice)',
-  mute: 'Mute (Voice)',
-  deafen: 'Deafen (Voice)',
-  move: 'Move (Voice)',
-  useVoiceActivity: 'Use Voice Activity',
-  nickname: 'Change Nickname',
-  manageNicknames: 'Manage Nicknames',
-  manageRoles: 'Manage Roles',
-  webhooks: 'Manage Webhooks',
-  emojis: 'Manage Emojis'
-}
-```
+[Can be viewed here.](./permissions-middleware/blob/master/index.js#L1)
+

--- a/README.md
+++ b/README.md
@@ -37,15 +37,24 @@ worker.commands
 
 ## Using discord-rose's error logging
 
-When using `permissionsMiddleware()` by default it will send the error as a plain text message to the user. If you want to have discord-rose send the error with its error handler you can add an option in the function:
+When using `permissionsMiddleware()` by default it will send the error as a  rose error message to the user. If you want to have the handler send the message in plain text you and add the following:
 ```js
 permissionsMiddleware({
-  sendAsRoseError: true
+  sendAsRoseError: false
 })
 ```
+- **Note:** If the permission "embed" is required and fails it will send as plain text. (this is a limitation of how rose sends errors)
 
 This will work with any custom messages you set.
 
+## Replying to the original message
+
+If you are using the the plain text response ([sendAsRoseError: false](#using-discord-roses-error-logging "sendAsRoseError = false")) you can have the reponse reply to the executors message:
+```js
+permsissionsMiddleare({
+  makeResponseAReply: true
+})
+```
 ## Custom message
 
 When using `permissionsMiddleware()` you can pass a custom message object with a function, that takes a function which takes the command context:
@@ -71,4 +80,48 @@ worker.commands
   .middleware(permissionsMiddleware({
     user: (ctx) => "You don't have permissions"
   }))
+```
+
+Creating custom messages but using the provided readable permissions:
+```js
+permissionsMiddleware({
+  user: (ctx) => `You don't have the required permissions you need: ${ctx.command.userPerms.map(p => permissionsMiddleware.humanReadable[p])}`
+})
+```
+
+## Default readable permisisons
+```json
+{
+  createInvites: 'Create Invites',
+  kick: 'Kick Members',
+  ban: 'Ban Members',
+  administrator: 'Administrator',
+  manageChannels: 'Manage Channels',
+  manageGuild: 'Manage Server',
+  addReactions: 'Add Reactions',
+  auditLog: 'View Audit Log',
+  prioritySpeaker: 'Priority Speaker',
+  stream: 'Stream',
+  viewChannel: 'View Channel(s)',
+  sendMessages: 'Send Messages',
+  tts: 'Send Text-to-Speech Messages',
+  manageMessages: 'Manage Messages',
+  embed: 'Embed Links',
+  files: 'Attach Files',
+  readHistory: 'Read Message History',
+  mentionEveryone: 'Mention \@everyone, \@here, and All Roles',
+  externalEmojis: 'Use External Emoji',
+  viewInsights: 'View Server Invites',
+  connect: 'Connect (Voice)',
+  speak: 'Speak (Voice)',
+  mute: 'Mute (Voice)',
+  deafen: 'Deafen (Voice)',
+  move: 'Move (Voice)',
+  useVoiceActivity: 'Use Voice Activity',
+  nickname: 'Change Nickname',
+  manageNicknames: 'Manage Nicknames',
+  manageRoles: 'Manage Roles',
+  webhooks: 'Manage Webhooks',
+  emojis: 'Manage Emojis'
+}
 ```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ By default it is
   user = (ctx) => `You are missing the following permissions: \`${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``
 }
 ```
+This will result in a message like: "I am missing the following permissions: `Embed Links`" or "You are missing the following permissions: `Manage Messages`"
+This will only show the permissions that are missing and not all the required permissions for the command. To show all the permissions the command uses [this](#using-the-default-readable-permissions) setup would show all the perms.
+
 
 Example for creating a custom message:
 
@@ -81,7 +84,7 @@ worker.commands
     user: (ctx) => "You don't have permissions"
   }))
 ```
-
+## Using the default readable permissions
 Creating custom messages but using the provided readable permissions:
 ```js
 permissionsMiddleware({
@@ -125,3 +128,4 @@ permissionsMiddleware({
   emojis: 'Manage Emojis'
 }
 ```
+[1]: #custom

--- a/index.js
+++ b/index.js
@@ -1,58 +1,4 @@
-const exportFunc = module.exports = ({
-  humanReadable = {
-    createInvites: 'Create Invites',
-    kick: 'Kick Members',
-    ban: 'Ban Members',
-    administrator: 'Administrator',
-    manageChannels: 'Manage Channels',
-    manageGuild: 'Manage Server',
-    addReactions: 'Add Reactions',
-    auditLog: 'View Audit Log',
-    prioritySpeaker: 'Priority Speaker',
-    stream: 'Stream',
-    viewChannel: 'View Channel(s)',
-    sendMessages: 'Send Messages',
-    tts: 'Send Text-to-Speech Messages',
-    manageMessages: 'Manage Messages',
-    embed: 'Embed Links',
-    files: 'Attach Files',
-    readHistory: 'Read Message History',
-    mentionEveryone: 'Mention \@everyone, \@here, and All Roles',
-    externalEmojis: 'Use External Emoji',
-    viewInsights: 'View Server Invites',
-    connect: 'Connect (Voice)',
-    speak: 'Speak (Voice)',
-    mute: 'Mute (Voice)',
-    deafen: 'Deafen (Voice)',
-    move: 'Move (Voice)',
-    useVoiceActivity: 'Use Voice Activity',
-    nickname: 'Change Nickname',
-    manageNicknames: 'Manage Nicknames',
-    manageRoles: 'Manage Roles',
-    webhooks: 'Manage Webhooks',
-    emojis: 'Manage Emojis'
-  },
-  my = (ctx) => `I am missing the following permissions: ${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
-  user = (ctx) => `You are missing the following permissions: ${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
-  sendAsRoseError = true,
-  makeResponseAReply = false
-} = {}) => {
-  return (ctx) => {
-      if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
-          if (sendAsRoseError) throw new Error(my(ctx))
-          makeResponseAReply ? ctx.reply(my(ctx)) : ctx.send(my(ctx))
-          return false
-      }
-      if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
-          if (sendAsRoseError) throw new Error(user(ctx))
-          makeResponseAReply ? ctx.reply(user(ctx)) : ctx.send(user(ctx))
-          return false
-      }
-      return true
-  }
-}
-
-exportFunc.humanReadable = {
+const humanReadableStrings = {
   createInvites: 'Create Invites',
   kick: 'Kick Members',
   ban: 'Ban Members',
@@ -85,3 +31,27 @@ exportFunc.humanReadable = {
   webhooks: 'Manage Webhooks',
   emojis: 'Manage Emojis'
 }
+
+const exportFunc = module.exports = ({
+  humanReadable = humanReadableStrings,
+  my = (ctx) => `I am missing the following permissions: ${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
+  user = (ctx) => `You are missing the following permissions: ${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
+  sendAsRoseError = true,
+  makeResponseAReply = false
+} = {}) => {
+  return (ctx) => {
+      if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
+          if (sendAsRoseError) throw new Error(my(ctx))
+          makeResponseAReply ? ctx.reply(my(ctx)) : ctx.send(my(ctx))
+          return false
+      }
+      if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
+          if (sendAsRoseError) throw new Error(user(ctx))
+          makeResponseAReply ? ctx.reply(user(ctx)) : ctx.send(user(ctx))
+          return false
+      }
+      return true
+  }
+}
+
+exportFunc.humanReadable = humanReadableStrings

--- a/index.js
+++ b/index.js
@@ -36,12 +36,12 @@ const exportFunc = module.exports = ({
   my = (perms, _ctx) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
   user = (perms, _ctx) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
 } = {}) => {
-  return (ctx) => {
+  return async (ctx) => {
     if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
-      return ctx.error(my(ctx.command.myPerms.filter(p => !ctx.myPerms(p)), ctx))
+      return ctx.error(await my(ctx.command.myPerms.filter(p => !ctx.myPerms(p)), ctx))
     }
     if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
-      return ctx.error(user(ctx.command.hasPerms.filter(p => !ctx.userPerms(p)), ctx))
+      return ctx.error(await user(ctx.command.hasPerms.filter(p => !ctx.userPerms(p)), ctx))
     }
     return true
   }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const humanReadableStrings = {
+const humanReadable = {
   createInvites: 'Create Invites',
   kick: 'Kick Members',
   ban: 'Ban Members',
@@ -33,27 +33,18 @@ const humanReadableStrings = {
 }
 
 const exportFunc = module.exports = ({
-  humanReadable = humanReadableStrings,
-  my = (perms, ctx) => `I am missing the following permissions: ${perms.map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
-  user = (perms, ctx) => `You are missing the following permissions: ${perms.map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
-  sendAsRoseError = true,
-  makeResponseAReply = false
+  my = (perms, _ctx) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
+  user = (perms, _ctx) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
 } = {}) => {
   return (ctx) => {
     if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
-      const perms = ctx.command.myPerms.filter(p => !ctx.myPerms(p))
-      if (sendAsRoseError) throw new Error(my(perms, ctx))
-      makeResponseAReply ? ctx.reply(my(perms, ctx)) : ctx.send(my(perms, ctx))
-      return false
+      return ctx.error(my(ctx.command.myPerms.filter(p => !ctx.myPerms(p)), ctx))
     }
     if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
-      const perms = ctx.command.userPerms.filter(p => !ctx.userPerms(p))
-      if (sendAsRoseError) throw new Error(user(perms, ctx))
-      makeResponseAReply ? ctx.reply(user(perms, ctx)) : ctx.send(user(perms, ctx))
-      return false
+      return ctx.error(user(ctx.command.hasPerms.filter(p => !ctx.userPerms(p)), ctx))
     }
     return true
   }
 }
 
-exportFunc.humanReadable = humanReadableStrings
+exportFunc.humanReadable = humanReadable

--- a/index.js
+++ b/index.js
@@ -1,52 +1,57 @@
-module.exports = ({
-  humanReadable = {
-      createInvites: 'Create Invites',
-      kick: 'Kick Members',
-      ban: 'Ban Members',
-      administrator: 'Administrator',
-      manageChannels: 'Manage Channels',
-      manageGuild: 'Manage Server',
-      addReactions: 'Add Reactions',
-      auditLog: 'View Audit Log',
-      prioritySpeaker: 'Priority Speaker',
-      stream: 'Stream',
-      viewChannel: 'View Channel(s)',
-      sendMessages: 'Send Messages',
-      tts: 'Send Text-to-Speech Messages',
-      manageMessages: 'Manage Messages',
-      embed: 'Embed Links',
-      files: 'Attach Files',
-      readHistory: 'Read Message History',
-      mentionEveryone: 'Mention \@everyone, \@here, and All Roles',
-      externalEmojis: 'Use External Emoji',
-      viewInsights: 'View Server Invites',
-      connect: 'Connect (Voice)',
-      speak: 'Speak (Voice)',
-      mute: 'Mute (Voice)',
-      deafen: 'Deafen (Voice)',
-      move: 'Move (Voice)',
-      useVoiceActivity: 'Use Voice Activity',
-      nickname: 'Change Nickname',
-      manageNicknames: 'Manage Nicknames',
-      manageRoles: 'Manage Roles',
-      webhooks: 'Manage Webhooks',
-      emojis: 'Manage Emojis'
-  },
-  my = (ctx) => `I am missing the following permissions: \`${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => humanReadable[p]).join('`, `')}\``,
-  user = (ctx) => `You are missing the following permissions: \`${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => humanReadable[p]).join('`, `')}\``,
-  sendAsRoseError = false
+const humanReadable = {
+  createInvites: 'Create Invites',
+  kick: 'Kick Members',
+  ban: 'Ban Members',
+  administrator: 'Administrator',
+  manageChannels: 'Manage Channels',
+  manageGuild: 'Manage Server',
+  addReactions: 'Add Reactions',
+  auditLog: 'View Audit Log',
+  prioritySpeaker: 'Priority Speaker',
+  stream: 'Stream',
+  viewChannel: 'View Channel(s)',
+  sendMessages: 'Send Messages',
+  tts: 'Send Text-to-Speech Messages',
+  manageMessages: 'Manage Messages',
+  embed: 'Embed Links',
+  files: 'Attach Files',
+  readHistory: 'Read Message History',
+  mentionEveryone: 'Mention \@everyone, \@here, and All Roles',
+  externalEmojis: 'Use External Emoji',
+  viewInsights: 'View Server Invites',
+  connect: 'Connect (Voice)',
+  speak: 'Speak (Voice)',
+  mute: 'Mute (Voice)',
+  deafen: 'Deafen (Voice)',
+  move: 'Move (Voice)',
+  useVoiceActivity: 'Use Voice Activity',
+  nickname: 'Change Nickname',
+  manageNicknames: 'Manage Nicknames',
+  manageRoles: 'Manage Roles',
+  webhooks: 'Manage Webhooks',
+  emojis: 'Manage Emojis'
+}
+
+const exportFunc = module.exports = ({
+  humanReadable = humanReadable,
+  my = (ctx) => `I am missing the following permissions: \`${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``,
+  user = (ctx) => `You are missing the following permissions: \`${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``,
+  sendAsRoseError = true,
+  makeResponseAReply = false
 } = {}) => {
   return (ctx) => {
       if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
           if (sendAsRoseError && ctx.myPerms('embed')) throw new Error(my(ctx))
-          ctx.reply(my(ctx))
+          makeResponseAReply ? ctx.reply(my(ctx)) : ctx.send(my(ctx))
           return false
       }
       if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
           if (sendAsRoseError) throw new Error(user(ctx))
-          ctx.reply(user(ctx))
+          makeResponseAReply ? ctx.reply(user(ctx)) : ctx.send(user(ctx))
           return false
       }
       return true
   }
 }
+
+exportFunc.humanReadable = humanReadable

--- a/index.js
+++ b/index.js
@@ -33,15 +33,15 @@ const humanReadable = {
 }
 
 const exportFunc = module.exports = ({
-  my = (perms, _ctx) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
-  user = (perms, _ctx) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
+  my = (_ctx, perms) => `I am missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
+  user = (_ctx, perms) => `You are missing the following permissions: ${perms.map(p => humanReadable[p] ?? p).join(', ')}`,
 } = {}) => {
   return async (ctx) => {
     if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
-      return ctx.error(await my(ctx.command.myPerms.filter(p => !ctx.myPerms(p)), ctx))
+      return ctx.error(await my(ctx, ctx.command.myPerms.filter(p => !ctx.myPerms(p))))
     }
     if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
-      return ctx.error(await user(ctx.command.hasPerms.filter(p => !ctx.userPerms(p)), ctx))
+      return ctx.error(await user(ctx, ctx.command.hasPerms.filter(p => !ctx.userPerms(p))))
     }
     return true
   }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,52 @@
 module.exports = ({
-  user = (ctx) => `You're the following permissions: ${ctx.command.userPerms.join(', ')}`,
-  my = (ctx) => `I'm missing the following permissions: ${ctx.command.myPerms.join(', ')}`
+  humanReadable = {
+      createInvites: 'Create Invites',
+      kick: 'Kick Members',
+      ban: 'Ban Members',
+      administrator: 'Administrator',
+      manageChannels: 'Manage Channels',
+      manageGuild: 'Manage Server',
+      addReactions: 'Add Reactions',
+      auditLog: 'View Audit Log',
+      prioritySpeaker: 'Priority Speaker',
+      stream: 'Stream',
+      viewChannel: 'View Channel(s)',
+      sendMessages: 'Send Messages',
+      tts: 'Send Text-to-Speech Messages',
+      manageMessages: 'Manage Messages',
+      embed: 'Embed Links',
+      files: 'Attach Files',
+      readHistory: 'Read Message History',
+      mentionEveryone: 'Mention \@everyone, \@here, and All Roles',
+      externalEmojis: 'Use External Emoji',
+      viewInsights: 'View Server Invites',
+      connect: 'Connect (Voice)',
+      speak: 'Speak (Voice)',
+      mute: 'Mute (Voice)',
+      deafen: 'Deafen (Voice)',
+      move: 'Move (Voice)',
+      useVoiceActivity: 'Use Voice Activity',
+      nickname: 'Change Nickname',
+      manageNicknames: 'Manage Nicknames',
+      manageRoles: 'Manage Roles',
+      webhooks: 'Manage Webhooks',
+      emojis: 'Manage Emojis'
+  },
+  my = (ctx) => `I am missing the following permissions: \`${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => humanReadable[p]).join('`, `')}\``,
+  user = (ctx) => `You are missing the following permissions: \`${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => humanReadable[p]).join('`, `')}\``,
+  sendAsRoseError = false
 } = {}) => {
   return (ctx) => {
-    if (ctx.command.userPerms && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
-      throw new Error(user(ctx))
-    }
-    if (ctx.command.myPerms && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
-      throw new Error(my(ctx))
-    }
-
-    return true
+      if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
+          if (sendAsRoseError && ctx.myPerms('embed')) throw new Error(my(ctx))
+          ctx.reply(my(ctx))
+          return false
+      }
+      if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
+          if (sendAsRoseError) throw new Error(user(ctx))
+          ctx.reply(user(ctx))
+          return false
+      }
+      return true
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,58 @@
-const humanReadable = {
+const exportFunc = module.exports = ({
+  humanReadable = {
+    createInvites: 'Create Invites',
+    kick: 'Kick Members',
+    ban: 'Ban Members',
+    administrator: 'Administrator',
+    manageChannels: 'Manage Channels',
+    manageGuild: 'Manage Server',
+    addReactions: 'Add Reactions',
+    auditLog: 'View Audit Log',
+    prioritySpeaker: 'Priority Speaker',
+    stream: 'Stream',
+    viewChannel: 'View Channel(s)',
+    sendMessages: 'Send Messages',
+    tts: 'Send Text-to-Speech Messages',
+    manageMessages: 'Manage Messages',
+    embed: 'Embed Links',
+    files: 'Attach Files',
+    readHistory: 'Read Message History',
+    mentionEveryone: 'Mention \@everyone, \@here, and All Roles',
+    externalEmojis: 'Use External Emoji',
+    viewInsights: 'View Server Invites',
+    connect: 'Connect (Voice)',
+    speak: 'Speak (Voice)',
+    mute: 'Mute (Voice)',
+    deafen: 'Deafen (Voice)',
+    move: 'Move (Voice)',
+    useVoiceActivity: 'Use Voice Activity',
+    nickname: 'Change Nickname',
+    manageNicknames: 'Manage Nicknames',
+    manageRoles: 'Manage Roles',
+    webhooks: 'Manage Webhooks',
+    emojis: 'Manage Emojis'
+  },
+  my = (ctx) => `I am missing the following permissions: ${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
+  user = (ctx) => `You are missing the following permissions: ${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
+  sendAsRoseError = true,
+  makeResponseAReply = false
+} = {}) => {
+  return (ctx) => {
+      if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
+          if (sendAsRoseError) throw new Error(my(ctx))
+          makeResponseAReply ? ctx.reply(my(ctx)) : ctx.send(my(ctx))
+          return false
+      }
+      if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
+          if (sendAsRoseError) throw new Error(user(ctx))
+          makeResponseAReply ? ctx.reply(user(ctx)) : ctx.send(user(ctx))
+          return false
+      }
+      return true
+  }
+}
+
+exportFunc.humanReadable = {
   createInvites: 'Create Invites',
   kick: 'Kick Members',
   ban: 'Ban Members',
@@ -31,27 +85,3 @@ const humanReadable = {
   webhooks: 'Manage Webhooks',
   emojis: 'Manage Emojis'
 }
-
-const exportFunc = module.exports = ({
-  humanReadable = humanReadable,
-  my = (ctx) => `I am missing the following permissions: \`${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``,
-  user = (ctx) => `You are missing the following permissions: \`${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) || p).join('`, `')}\``,
-  sendAsRoseError = true,
-  makeResponseAReply = false
-} = {}) => {
-  return (ctx) => {
-      if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
-          if (sendAsRoseError && ctx.myPerms('embed')) throw new Error(my(ctx))
-          makeResponseAReply ? ctx.reply(my(ctx)) : ctx.send(my(ctx))
-          return false
-      }
-      if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
-          if (sendAsRoseError) throw new Error(user(ctx))
-          makeResponseAReply ? ctx.reply(user(ctx)) : ctx.send(user(ctx))
-          return false
-      }
-      return true
-  }
-}
-
-exportFunc.humanReadable = humanReadable

--- a/index.js
+++ b/index.js
@@ -34,23 +34,25 @@ const humanReadableStrings = {
 
 const exportFunc = module.exports = ({
   humanReadable = humanReadableStrings,
-  my = (ctx) => `I am missing the following permissions: ${ctx.command.myPerms.filter(p => !ctx.myPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
-  user = (ctx) => `You are missing the following permissions: ${ctx.command.userPerms.filter(p => !ctx.userPerms(p)).map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
+  my = (perms, ctx) => `I am missing the following permissions: ${perms.map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
+  user = (perms, ctx) => `You are missing the following permissions: ${perms.map(p => (typeof humanReadable === 'function' ? humanReadable(ctx, p) : humanReadable[p]) ?? p).join(', ')}`,
   sendAsRoseError = true,
   makeResponseAReply = false
 } = {}) => {
   return (ctx) => {
-      if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
-          if (sendAsRoseError) throw new Error(my(ctx))
-          makeResponseAReply ? ctx.reply(my(ctx)) : ctx.send(my(ctx))
-          return false
-      }
-      if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
-          if (sendAsRoseError) throw new Error(user(ctx))
-          makeResponseAReply ? ctx.reply(user(ctx)) : ctx.send(user(ctx))
-          return false
-      }
-      return true
+    if (ctx.command.hasOwnProperty('myPerms') && !ctx.command.myPerms.every(x => ctx.myPerms(x))) {
+      const perms = ctx.command.myPerms.filter(p => !ctx.myPerms(p))
+      if (sendAsRoseError) throw new Error(my(perms, ctx))
+      makeResponseAReply ? ctx.reply(my(perms, ctx)) : ctx.send(my(perms, ctx))
+      return false
+    }
+    if (ctx.command.hasOwnProperty('userPerms') && !ctx.command.userPerms.every(x => ctx.hasPerms(x))) {
+      const perms = ctx.command.userPerms.filter(p => !ctx.userPerms(p))
+      if (sendAsRoseError) throw new Error(user(perms, ctx))
+      makeResponseAReply ? ctx.reply(user(perms, ctx)) : ctx.send(user(perms, ctx))
+      return false
+    }
+    return true
   }
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,8 +17,10 @@ declare module 'discord-rose/dist/typings/lib' {
 type msgFunction = (ctx: CommandContext) => string
 
 declare const _default: (msgs?: {
+  humanReadable: object,
   my: msgFunction,
   user: msgFunction
+  sendAsRoseError: boolean
 }) => (ctx: CommandContext) => boolean
 
 export default _default

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,26 +1,86 @@
 import { bits } from 'discord-rose/dist/utils/Permissions'
 import { CommandContext } from "discord-rose/dist/structures/CommandContext";
 
+type bitKey = (keyof typeof bits)[]
+
 declare module 'discord-rose/dist/typings/lib' {
   interface CommandOptions {
     /**
      * Whether or not the executing user has said permissions
      */
-    userPerms?: (keyof typeof bits)[]
+    userPerms?: bitKey
     /**
      * Whether or not the bot has said permissions
      */
-    myPerms?: (keyof typeof bits)[]
+    myPerms?: bitKey
   }
+}
+
+type humanReadableBits = {
+  createInvites?: string;
+  kick?: string;
+  ban?: string;
+  administrator?: string;
+  manageChannels?: string;
+  manageGuild?: string;
+  addReactions?: string;
+  auditLog?: string;
+  prioritySpeaker?: string;
+  stream?: string;
+  viewChannel?: string;
+  sendMessages?: string;
+  tts?: string;
+  manageMessages?: string;
+  embed?: string;
+  files?: string;
+  readHistory?: string;
+  mentionEveryone?: string;
+  externalEmojis?: string;
+  viewInsights?: string;
+  connect?: string;
+  speak?: string;
+  mute?: string;
+  deafen?: string;
+  move?: string;
+  useVoiceActivity?: string;
+  nickname?: string;
+  manageNicknames?: string;
+  manageRoles?: string;
+  webhooks?: string;
+  emojis?: string;
 }
 
 type msgFunction = (ctx: CommandContext) => string
 
-declare const _default: (msgs?: {
-  humanReadable: object,
-  my: msgFunction,
-  user: msgFunction
-  sendAsRoseError: boolean
+declare const _default: (opts?: {
+  /**
+   * Object of readable strings mapped to permissions bit strings or function for dynamic readable conversion
+   */
+  humanReadable?: humanReadableBits | ((ctx: CommandContext, p: (keyof typeof bits)[]) => string)
+  /**
+   * Message that returns if bot requires permissions
+   */
+  my?: msgFunction,
+  /**
+   * Message that returns if user requrires permissions
+   */
+  user?: msgFunction
+  /**
+   * Have the error return as a rose error or sent in plaintext
+   */
+  sendAsRoseError?: boolean
+  /**
+   * Have the error response be a reply if sendAsRoseError is false
+   */
+  makeResponseAReply?: boolean
 }) => (ctx: CommandContext) => boolean
 
 export default _default
+
+/**
+ * A JSON of the default provided bits
+ */
+export const humanReadable: {
+  key: (keyof typeof bits)[],
+  value: string
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -20,7 +20,7 @@ type humanReadableBits = {
   [key in bitKey[number]]?: string
 }
 
-type msgFunction = (perms: (keyof typeof bits)[], ctx: CommandContext) => string
+type msgFunction = (ctx: CommandContext, perms: (keyof typeof bits)[]) => string
 
 declare const _default: (opts?: {
   /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -24,10 +24,6 @@ type msgFunction = (perms: (keyof typeof bits)[], ctx: CommandContext) => string
 
 declare const _default: (opts?: {
   /**
-   * Object of readable strings mapped to permissions bit strings or function for dynamic readable conversion
-   */
-  humanReadable?: humanReadableBits | ((ctx: CommandContext, p: (keyof typeof bits)[]) => string)
-  /**
    * Message that returns if bot requires permissions
    */
   my?: msgFunction,
@@ -35,14 +31,6 @@ declare const _default: (opts?: {
    * Message that returns if user requrires permissions
    */
   user?: msgFunction
-  /**
-   * Have the error return as a rose error or sent in plaintext
-   */
-  sendAsRoseError?: boolean
-  /**
-   * Have the error response be a reply if sendAsRoseError is false
-   */
-  makeResponseAReply?: boolean
 }) => (ctx: CommandContext) => boolean
 
 export default _default

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 import { bits } from 'discord-rose/dist/utils/Permissions'
-import { CommandContext } from "discord-rose/dist/structures/CommandContext";
+import { CommandContext } from "discord-rose/dist/typings/lib";
 
 type bitKey = (keyof typeof bits)[]
 
@@ -20,7 +20,7 @@ type humanReadableBits = {
   [key in bitKey[number]]?: string
 }
 
-type msgFunction = (ctx: CommandContext, perms: (keyof typeof bits)[]) => string
+type msgFunction = (ctx: CommandContext, perms: (keyof typeof bits)[]) => Promise<string> | string
 
 declare const _default: (opts?: {
   /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -20,7 +20,7 @@ type humanReadableBits = {
   [key in bitKey[number]]?: string
 }
 
-type msgFunction = (ctx: CommandContext) => string
+type msgFunction = (perms: (keyof typeof bits)[], ctx: CommandContext) => string
 
 declare const _default: (opts?: {
   /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,38 +16,8 @@ declare module 'discord-rose/dist/typings/lib' {
   }
 }
 
-type humanReadableBits = {
-  createInvites?: string;
-  kick?: string;
-  ban?: string;
-  administrator?: string;
-  manageChannels?: string;
-  manageGuild?: string;
-  addReactions?: string;
-  auditLog?: string;
-  prioritySpeaker?: string;
-  stream?: string;
-  viewChannel?: string;
-  sendMessages?: string;
-  tts?: string;
-  manageMessages?: string;
-  embed?: string;
-  files?: string;
-  readHistory?: string;
-  mentionEveryone?: string;
-  externalEmojis?: string;
-  viewInsights?: string;
-  connect?: string;
-  speak?: string;
-  mute?: string;
-  deafen?: string;
-  move?: string;
-  useVoiceActivity?: string;
-  nickname?: string;
-  manageNicknames?: string;
-  manageRoles?: string;
-  webhooks?: string;
-  emojis?: string;
+type humanReadable = {
+  [key in bitKey[number]]: string
 }
 
 type msgFunction = (ctx: CommandContext) => string

--- a/types.d.ts
+++ b/types.d.ts
@@ -50,7 +50,4 @@ export default _default
 /**
  * A JSON of the default provided bits
  */
-export const humanReadable: {
-  key: (keyof typeof bits)[],
-  value: string
-}
+export const humanReadable: humanReadableBits

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,8 +16,8 @@ declare module 'discord-rose/dist/typings/lib' {
   }
 }
 
-type humanReadable = {
-  [key in bitKey[number]]: string
+type humanReadableBits = {
+  [key in bitKey[number]]?: string
 }
 
 type msgFunction = (ctx: CommandContext) => string


### PR DESCRIPTION
Changes:
- Add human readable permission names to error message
- If embed perm is missing response will be in plain text even with rose error logging enabled
- Only show the perms that are actually missing on user and bot
- Add option for rose error logging
- Put each required perm in an inline embed